### PR TITLE
RPC Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+redskull
 
 # Vim
 *.swp

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ type LaunchConfig struct {
 	SentinelHostAddress string
 	TemplateDirectory   string
 	NodeRefreshInterval float64
+	RPCPort             int
 }
 
 var config LaunchConfig
@@ -87,6 +88,11 @@ func init() {
 			config.Port = 8000
 		}
 	}
+
+	if config.RPCPort == 0 {
+		config.RPCPort = config.Port + 1
+	}
+
 	ps := fmt.Sprintf("%s:%d", config.IP, config.Port)
 	log.Printf("binding to '%s'", ps)
 	flag.Set("bind", ps)
@@ -144,6 +150,8 @@ func main() {
 	log.Printf("Main Cache Stats: %+v", mc.AuthCache.GetStats())
 	log.Printf("Hot Cache Stats: %+v", mc.AuthCache.GetHotStats())
 	handlers.SetConstellation(mc)
+
+	go ServeRPC()
 
 	// HTML Interface URLS
 	goji.Get("/constellation/", handlers.ConstellationInfoHTML) // Needs moved? instance tree?

--- a/rpcclient/client.go
+++ b/rpcclient/client.go
@@ -1,0 +1,89 @@
+package rsclient
+
+import (
+	"errors"
+	"log"
+	"net"
+	"net/rpc"
+	"time"
+
+	"github.com/therealbill/redskull/actions"
+)
+
+type (
+	Client struct {
+		connection *rpc.Client
+	}
+)
+
+type NewPodRequest struct {
+	Name   string
+	IP     string
+	Port   int
+	Quorum int
+	Auth   string
+}
+
+func NewClient(dsn string, timeout time.Duration) (*Client, error) {
+	connection, err := net.DialTimeout("tcp", dsn, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{connection: rpc.NewClient(connection)}, nil
+}
+
+func (c *Client) AddSentinel(address string) (bool, error) {
+	var ok bool
+	err := c.connection.Call("RPC.AddSentinel", address, &ok)
+	if err != nil {
+		log.Print(err)
+	} else {
+		ok = true
+	}
+	return ok, err
+}
+
+func (c *Client) AddPod(name, ip string, port, quorum int, auth string) (actions.RedisPod, error) {
+	var pod actions.RedisPod
+	pr := NewPodRequest{Name: name, IP: ip, Port: port, Quorum: quorum, Auth: auth}
+	err := c.connection.Call("RPC.AddPod", pr, &pod)
+	if err != nil {
+		log.Print(err)
+	}
+	return pod, err
+
+}
+
+func (c *Client) GetPod(podname string) (actions.RedisPod, error) {
+	var pod actions.RedisPod
+	err := c.connection.Call("RPC.GetPod", podname, &pod)
+	if err != nil {
+		log.Print(err)
+	}
+	return pod, err
+}
+
+func (c *Client) RemovePod(podname string) error {
+	ok := false
+	err := c.connection.Call("RPC.RemovePod", podname, &ok)
+	if err != nil {
+		log.Printf("ok=%s,Error: %s", ok, err.Error())
+		return err
+	}
+	if !ok {
+		return errors.New("Unable to remove pod")
+	}
+	return nil
+}
+
+func (c *Client) BalancePod(podname string) error {
+	ok := false
+	err := c.connection.Call("RPC.BalancePod", podname, &ok)
+	if !ok {
+		if err != nil {
+			log.Printf("Error: %s", err.Error())
+		}
+		return errors.New("Was unable to initiate balance operation")
+	}
+	return nil
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -50,7 +50,7 @@ func (r *RPC) AddPod(pr NewPodRequest, resp *actions.RedisPod) (err error) {
 		err = errors.New("MonitorPod call returned false, no error")
 	}
 	time.Sleep(time.Second * 2)
-	pod, err := r.constellation.GetPod(podname)
+	pod, err := r.constellation.GetPod(pr.Name)
 	if pod == nil || pod.Name == "" {
 		err = errors.New("New Pod Not found")
 		return err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/rpc"
+	"sync"
+	"time"
+
+	"github.com/therealbill/redskull/actions"
+	"github.com/therealbill/redskull/handlers"
+)
+
+type NewPodRequest struct {
+	Name   string
+	IP     string
+	Port   int
+	Quorum int
+	Auth   string
+}
+
+type Item struct {
+	key  string
+	Item interface{}
+}
+
+type RPC struct {
+	constellation *actions.Constellation
+	mu            *sync.RWMutex
+}
+
+func badContextError(err error) {
+	if err != nil {
+		panic("Constellation is not initialized")
+	}
+}
+
+func (r *RPC) AddPod(pr NewPodRequest, resp *actions.RedisPod) (err error) {
+	gob.Register(actions.RedisPod{})
+	ok, err := r.constellation.MonitorPod(pr.Name, pr.IP, pr.Port, pr.Quorum, pr.Auth)
+	if err != nil {
+		log.Printf("MonitorPod call ('%+v') Failed. Error: %s", pr, err.Error())
+		return err
+	}
+	if !ok {
+		log.Printf("MonitorPod call ('%+v') Failed. No Error", pr)
+		err = errors.New("MonitorPod call returned false, no error")
+	}
+	time.Sleep(time.Second * 2)
+	pod, err := r.constellation.GetPod(podname)
+	if pod == nil || pod.Name == "" {
+		err = errors.New("New Pod Not found")
+		return err
+	}
+	*resp = *pod
+	return err
+
+}
+func (r *RPC) GetPod(podname string, resp *actions.RedisPod) (err error) {
+	gob.Register(actions.RedisPod{})
+	pod, err := r.constellation.GetPod(podname)
+	if pod == nil || pod.Name == "" {
+		err = errors.New("Pod Not found")
+		return err
+	}
+	*resp = *pod
+	return err
+}
+
+func (r *RPC) RemovePod(podname string, resp *bool) (err error) {
+	ok, err := r.constellation.RemovePod(podname)
+	*resp = ok
+	return err
+}
+
+func (r *RPC) AddSentinel(address string, resp *bool) (err error) {
+	err = r.constellation.AddSentinelByAddress(address)
+	if err == nil {
+		*resp = true
+	}
+	return err
+}
+
+func (r *RPC) BalancePod(podname string, resp *bool) (err error) {
+	pod, err := r.constellation.GetPod(podname)
+	if pod == nil || pod.Name == "" {
+		err = errors.New("Pod Not found")
+		*resp = false
+	}
+	r.constellation.BalancePod(pod)
+	*resp = true
+	return err
+}
+
+func NewRPC() *RPC {
+	context, err := handlers.NewPageContext()
+	badContextError(err)
+	return &RPC{
+		constellation: context.Constellation,
+	}
+}
+
+func ServeRPC() {
+	rpc.Register(NewRPC())
+	rpc_on := fmt.Sprintf("%s:%d", config.BindAddress, config.RPCPort)
+	l, e := net.Listen("tcp", rpc_on)
+	if e != nil {
+		log.Fatal("listen error:", e)
+	}
+
+	rpc.Accept(l)
+}


### PR DESCRIPTION
The primary feature here is the addition of an RPC Server in go which will run on config.Port+1. There is also a sub-package called rpcclient which provides a client-side library for interacting with RS over the RPC mechanism.

In this initial release of RPC the following capabilities are exposed:
* Adding a sentinel to the constellation
* Adding a Pod to be monitored
* Removing a Pod from all sentinels
* Pulling a Pod down (for it's information)
* Executing a Balance operation on a pod